### PR TITLE
feat: Add force upload to `prepdocs.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ If you've changed the infrastructure files (`infra` folder or `azure.yaml`), the
 
 ```azd up```
 
+When using the same local workspace to re-provision in a new environment, you might notice that the
+application- although functional- lacks the specialised information normally provided through the
+uploaded documents.
+This is likely because the AI Search service is empty, a symptom of the optimisation introduced
+[here](https://github.com/Azure-Samples/azure-search-openai-demo/pull/835), which enabled skipping
+the upload of files that have been processed locally before.
+You can disable this feature by setting the `FORCE_DOC_UPLOAD` environment variable before
+provisioning, thus ensuring that the files are uploaded to the new index:
+
+```shell
+azd env set FORCE_DOC_UPLOAD true
+```
+
 ## Sharing environments
 
 To give someone else access to a completely deployed and existing environment,

--- a/app/backend/prepdocs.py
+++ b/app/backend/prepdocs.py
@@ -79,6 +79,7 @@ def setup_blob_manager(
 def setup_list_file_strategy(
     azure_credential: AsyncTokenCredential,
     local_files: Union[str, None],
+    check_md5: Union[bool, None],
     datalake_storage_account: Union[str, None],
     datalake_filesystem: Union[str, None],
     datalake_path: Union[str, None],
@@ -98,7 +99,7 @@ def setup_list_file_strategy(
         )
     elif local_files:
         logger.info("Using local files: %s", local_files)
-        list_file_strategy = LocalListFileStrategy(path_pattern=local_files)
+        list_file_strategy = LocalListFileStrategy(path_pattern=local_files, check_md5=check_md5)
     else:
         raise ValueError("Either local_files or datalake_storage_account must be provided.")
     return list_file_strategy
@@ -221,6 +222,9 @@ if __name__ == "__main__":
         epilog="Example: prepdocs.py '.\\data\*' --storageaccount myaccount --container mycontainer --searchservice mysearch --index myindex -v",
     )
     parser.add_argument("files", nargs="?", help="Files to be processed")
+    parser.add_argument(
+        "--forceupload", action="store_true", help="Optional. Force upload by bypassing file hash check"
+    )
     parser.add_argument(
         "--datalakestorageaccount", required=False, help="Optional. Azure Data Lake Storage Gen2 Account name"
     )
@@ -417,6 +421,7 @@ if __name__ == "__main__":
     list_file_strategy = setup_list_file_strategy(
         azure_credential=azd_credential,
         local_files=args.files,
+        check_md5=not args.forceupload,
         datalake_storage_account=args.datalakestorageaccount,
         datalake_filesystem=args.datalakefilesystem,
         datalake_path=args.datalakepath,

--- a/docs/data_ingestion.md
+++ b/docs/data_ingestion.md
@@ -54,6 +54,10 @@ If needed, you can modify the chunking algorithm in `scripts/prepdocslib/textspl
 To upload more PDFs, put them in the data/ folder and run `./scripts/prepdocs.sh` or `./scripts/prepdocs.ps1`.
 
 A [recent change](https://github.com/Azure-Samples/azure-search-openai-demo/pull/835) added checks to see what's been uploaded before. The prepdocs script now writes an .md5 file with an MD5 hash of each file that gets uploaded. Whenever the prepdocs script is re-run, that hash is checked against the current hash and the file is skipped if it hasn't changed.
+This can be an issue when redeploying in a new environment; although the index is empty, the script
+detects the local .md5 files and, consequently, skips the upload.
+In order to bypass this behaviour, the script can be run with the `--forceupload` option, set via
+the `FORCE_DOC_UPLOAD` environment variable when running the automation scripts (e.g. `azd up`).
 
 ### Removing documents
 

--- a/samples/data-ingestion/README.md
+++ b/samples/data-ingestion/README.md
@@ -74,6 +74,10 @@ If needed, you can modify the chunking algorithm in `scripts/prepdocslib/textspl
 To upload more PDFs, put them in the data/ folder and run `./scripts/prepdocs.sh` or `./scripts/prepdocs.ps1`.
 
 A [recent change](https://github.com/Azure-Samples/azure-search-openai-demo/pull/835) added checks to see what's been uploaded before. The prepdocs script now writes an .md5 file with an MD5 hash of each file that gets uploaded. Whenever the prepdocs script is re-run, that hash is checked against the current hash and the file is skipped if it hasn't changed.
+This can be an issue when redeploying in a new environment; although the index is empty, the script
+detects the local .md5 files and, consequently, skips the upload.
+In order to bypass this behaviour, the script can be run with the `--forceupload` option, set via
+the `FORCE_DOC_UPLOAD` environment variable when running the automation scripts (e.g. `azd up`).
 
 ### Removing documents
 

--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -71,10 +71,15 @@ if ($env:AZURE_OPENAI_API_KEY) {
   $openaiApiKeyArg = "--openaikey $env:OPENAI_API_KEY"
 }
 
+if ($env:FORCE_DOC_UPLOAD -eq $true) {
+  $forceUploadArg = "--forceupload"
+}
+
 $cwd = (Get-Location)
 $dataArg = "`"$cwd/data/*`""
 
 $argumentList = "./app/backend/prepdocs.py $dataArg --verbose " + `
+"$forceUploadArg " + `
 "--subscriptionid $env:AZURE_SUBSCRIPTION_ID " + `
 "--storageaccount $env:AZURE_STORAGE_ACCOUNT --container $env:AZURE_STORAGE_CONTAINER --storageresourcegroup $env:AZURE_STORAGE_RESOURCE_GROUP " + `
 "--searchservice $env:AZURE_SEARCH_SERVICE --index $env:AZURE_SEARCH_INDEX " + `

--- a/scripts/prepdocs.sh
+++ b/scripts/prepdocs.sh
@@ -69,7 +69,12 @@ elif [ -n "$OPENAI_API_KEY" ]; then
   openAiApiKeyArg="--openaikey $OPENAI_API_KEY"
 fi
 
+if [ "$FORCE_DOC_UPLOAD" = true ]; then
+  forceUploadArg="--forceupload"
+fi
+
 ./.venv/bin/python ./app/backend/prepdocs.py './data/*' --verbose \
+$forceUploadArg \
 --subscriptionid $AZURE_SUBSCRIPTION_ID  \
 --storageaccount "$AZURE_STORAGE_ACCOUNT" --container "$AZURE_STORAGE_CONTAINER" --storageresourcegroup $AZURE_STORAGE_RESOURCE_GROUP \
 --searchservice "$AZURE_SEARCH_SERVICE" --index "$AZURE_SEARCH_INDEX" \

--- a/tests/test_listfilestrategy.py
+++ b/tests/test_listfilestrategy.py
@@ -123,12 +123,16 @@ def test_locallistfilestrategy_checkmd5():
             md5_file.write(f1_hash)
 
         local_list_strategy = LocalListFileStrategy(path_pattern=f"{tmpdirname}/*")
+        local_list_strategy_no_check = LocalListFileStrategy(path_pattern=f"{tmpdirname}/*", check_md5=False)
         assert local_list_strategy.check_md5(md5_file.name) is True
         assert local_list_strategy.check_md5(pdf_file.name) is True
+        assert local_list_strategy_no_check.check_md5(md5_file.name) is True
+        assert local_list_strategy_no_check.check_md5(pdf_file.name) is False
         # now change the file, hash should no longer match
         with open(os.path.join(tmpdirname, "test.pdf"), "w") as pdf_file:
             pdf_file.write("test2")
         assert local_list_strategy.check_md5(pdf_file.name) is False
+        assert local_list_strategy_no_check.check_md5(pdf_file.name) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose

Add a new CLI flag (`--forceupload`) to prepdocs.py that will force the upload of the document to the index, even if the '.md5' file is present locally.

Refs Azure-Samples/azure-search-openai-demo#1779

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [X] No

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

- [ ] Yes
- [X] No

## Type of change

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
