### PR TITLE
gh: Fix markdown formatting in issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,16 +1,15 @@
 <!--
 IF SUFFICIENT INFORMATION IS NOT PROVIDED VIA THE FOLLOWING TEMPLATE THE ISSUE MIGHT BE CLOSED WITHOUT FURTHER CONSIDERATION OR INVESTIGATION
 -->
-> Please provide us with the following information:
-> ---------------------------------------------------------------
+<!-- Please provide us with the following information: -->
+---------------------------------------------------------------
 
 ### This issue is for a: (mark with an `x`)
-```
+
 - [ ] bug report -> please search issues before submitting
 - [ ] feature request
 - [ ] documentation issue or request
 - [ ] regression (a behavior that used to work and stopped in a new release)
-```
 
 ### Minimal steps to reproduce
 >
@@ -22,15 +21,17 @@ IF SUFFICIENT INFORMATION IS NOT PROVIDED VIA THE FOLLOWING TEMPLATE THE ISSUE M
 >
 
 ### OS and Version?
-> Windows 7, 8 or 10. Linux (which distribution). macOS (Yosemite? El Capitan? Sierra?)
+
+<!-- Windows 7, 8 or 10. Linux (which distribution). macOS (Yosemite? El Capitan? Sierra?) -->
 
 ### azd version?
-> run `azd version` and copy paste here.
+
+<!-- run `azd version` and copy paste here. -->
 
 ### Versions
 >
 
 ### Mention any other details that might be useful
 
-> ---------------------------------------------------------------
-> Thanks! We'll be in touch soon.
+---------------------------------------------------------------
+<!-- Thanks! We'll be in touch soon. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,10 +8,8 @@
 When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
 If you're not sure, try it out on an old environment.
 
-```
-[ ] Yes
-[ ] No
-```
+- [ ] Yes
+- [ ] No
 
 ## Does this require changes to learn.microsoft.com docs?
 
@@ -19,21 +17,17 @@ This repository is referenced by [this tutorial](https://learn.microsoft.com/azu
 which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
 check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.
 
-```
-[ ] Yes
-[ ] No
-```
+- [ ] Yes
+- [ ] No
 
 ## Type of change
 
-```
-[ ] Bugfix
-[ ] Feature
-[ ] Code style update (formatting, local variables)
-[ ] Refactoring (no functional changes, no api changes)
-[ ] Documentation content changes
-[ ] Other... Please describe:
-```
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Documentation content changes
+- [ ] Other... Please describe:
 
 ## Code quality checklist
 


### PR DESCRIPTION
The existing version of the issue and PR templates is malformatted and severely triggers my OCD every time I have to fix it manually. This should take a second to review, but it will make me forever grateful.