### PR TITLE
fix: Reduce coverage requirement to 80%

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -58,7 +58,7 @@ jobs:
           run: black . --check --verbose
         - name: Run Python tests
           if: runner.os != 'Windows'
-          run: python3 -m pytest -s -vv --cov --cov-fail-under=86
+          run: python3 -m pytest -s -vv --cov --cov-fail-under=80
         - name: Run E2E tests with Playwright
           id: e2e
           if: runner.os != 'Windows'


### PR DESCRIPTION
The CI is currently too brittle, especially on Python 3.9 (blobmanager tests are skipped there resulting in a lower coverage). This change, reduces the coverage requirement from 86% to 80% to make the CI more stable, happily sacrificing the Engineer of the Year award for the sake of our mental health.