### PR TITLE
Hot fix: fixed the failing deployment when model is not set

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -591,9 +591,11 @@ async def setup_clients():
     available_models = get_supported_models(deployment_information)
 
     current_model = list(available_models.keys())[0] if DEFAULT_MODEL is None else DEFAULT_MODEL
-
-    if DEFAULT_MODEL is not None and DEFAULT_MODEL not in available_models.keys():
-        raise ValueError(f"DEFAULT_MODEL must be set to a supported model from {available_models.keys()}")
+    if current_model and current_model not in available_models.keys():
+        raise ValueError(
+            f"DEFAULT_MODEL must be set to a supported model from\
+                         {available_models.keys()}.\nCurrent model is set to {current_model}"
+        )
 
     if not HUGGINGFACE_API_KEY:
         raise ValueError("HUGGINGFACE_API_KEY must be set if you want to use full capabilities.")


### PR DESCRIPTION
## Purpose

This PR is supposed to fix a scenario when the DEFAULT_MODEL is not set and the gunicorn application cannot start up.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
