### PR TITLE
feat: Add tests for available models retrieval

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 *.sh text eol=lf
 *.jsonlines text eol=lf
 * text eol=lf
+*.png -text
+*.pdf -text

--- a/tests/test_supported_models.py
+++ b/tests/test_supported_models.py
@@ -1,16 +1,4 @@
-import pytest
-
 from templates.supported_models import MODEL_CONFIGS, ModelConfig, get_supported_models
-
-
-@pytest.fixture
-def sample_azure_deployment():
-    return {"type": "azure", "model_name": "gpt-35-turbo", "deployment_name": "azure"}
-
-
-@pytest.fixture
-def sample_openai_deployment():
-    return {"type": "openai", "model_name": "gpt-3.5-turbo", "deployment_name": ""}
 
 
 def test_model_config_structure():
@@ -20,6 +8,7 @@ def test_model_config_structure():
         assert isinstance(
             config, (dict, ModelConfig)
         ), "Model configuration entry can either be a 'dict' or a 'ModelConfig' object."
+
         if isinstance(config, dict):
             has_model_config = all(isinstance(value, ModelConfig) for value in config.values())
             assert has_model_config, f"Model configuration for '{model_name}' must be a 'ModelConfig' object."

--- a/tests/test_supported_models.py
+++ b/tests/test_supported_models.py
@@ -1,0 +1,75 @@
+import pytest
+
+from templates.supported_models import MODEL_CONFIGS, ModelConfig, get_supported_models
+
+
+@pytest.fixture
+def sample_azure_deployment():
+    return {"type": "azure", "model_name": "gpt-35-turbo", "deployment_name": "azure"}
+
+
+@pytest.fixture
+def sample_openai_deployment():
+    return {"type": "openai", "model_name": "gpt-3.5-turbo", "deployment_name": ""}
+
+
+def test_model_config_structure():
+    assert isinstance(MODEL_CONFIGS, dict)
+
+    for model_name, config in MODEL_CONFIGS.items():
+        if isinstance(config, dict):
+            # Ensure both 'openai' and 'azure' keys exist in the dictionary
+            assert "openai" in config, f"{model_name} config should have an 'openai' entry."
+            assert "azure" in config, f"{model_name} config should have an 'azure' entry."
+            assert isinstance(
+                config["openai"], ModelConfig
+            ), f"The 'openai' entry for {model_name} should be a ModelConfig."
+            assert isinstance(
+                config["azure"], ModelConfig
+            ), f"The 'azure' entry for {model_name} should be a ModelConfig."
+
+        elif isinstance(config, ModelConfig):
+            assert config.type == "hf", f"{model_name} should be a Hugging Face model."
+
+
+def test_get_supported_models_with_azure(sample_azure_deployment):
+    supported_models = get_supported_models(sample_azure_deployment)
+
+    assert "GPT 3.5 Turbo" in supported_models
+    assert supported_models["GPT 3.5 Turbo"].identifier == "azure"
+    assert supported_models["GPT 3.5 Turbo"].model_name == "gpt-35-turbo"
+    assert supported_models["GPT 3.5 Turbo"].type == "openai"
+
+    assert "Mistral AI 7B" in supported_models
+    assert supported_models["Mistral AI 7B"].type == "hf"
+
+
+def test_get_supported_models_with_openai_fallback(sample_openai_deployment):
+    supported_models = get_supported_models(sample_openai_deployment)
+
+    assert "GPT 3.5 Turbo" in supported_models
+    assert supported_models["GPT 3.5 Turbo"].identifier == "gpt-3.5-turbo"
+    assert supported_models["GPT 3.5 Turbo"].model_name == "gpt-3.5-turbo"
+    assert supported_models["GPT 3.5 Turbo"].type == "openai"
+
+    assert "Mistral AI 7B" in supported_models
+    assert supported_models["Mistral AI 7B"].type == "hf"
+
+
+def test_get_supported_models_hugging_face_only():
+    openai_deployment = {"type": None, "model_name": None, "deployment_name": None}
+    supported_models = get_supported_models(openai_deployment)
+
+    assert "GPT 3.5 Turbo" not in supported_models
+    assert "Mistral AI 7B" in supported_models
+    assert supported_models["Mistral AI 7B"].type == "hf"
+    assert "Llama 3 8B Instruct" in supported_models
+
+
+def test_get_supported_models_invalid_openai_deployment():
+    openai_deployment = {"type": "unknown_type", "model_name": "gpt-3.5-turbo", "deployment_name": None}
+    supported_models = get_supported_models(openai_deployment)
+
+    assert "GPT 3.5 Turbo" not in supported_models
+    assert "Mistral AI 7B" in supported_models
+    assert supported_models["Mistral AI 7B"].type == "hf"

--- a/tests/test_supported_models.py
+++ b/tests/test_supported_models.py
@@ -17,22 +17,16 @@ def test_model_config_structure():
     assert isinstance(MODEL_CONFIGS, dict)
 
     for model_name, config in MODEL_CONFIGS.items():
+        assert isinstance(
+            config, (dict, ModelConfig)
+        ), "Model configuration entry can either be a 'dict' or a 'ModelConfig' object."
         if isinstance(config, dict):
-            # Ensure both 'openai' and 'azure' keys exist in the dictionary
-            assert "openai" in config, f"{model_name} config should have an 'openai' entry."
-            assert "azure" in config, f"{model_name} config should have an 'azure' entry."
-            assert isinstance(
-                config["openai"], ModelConfig
-            ), f"The 'openai' entry for {model_name} should be a ModelConfig."
-            assert isinstance(
-                config["azure"], ModelConfig
-            ), f"The 'azure' entry for {model_name} should be a ModelConfig."
-
-        elif isinstance(config, ModelConfig):
-            assert config.type == "hf", f"{model_name} should be a Hugging Face model."
+            has_model_config = all(isinstance(value, ModelConfig) for value in config.values())
+            assert has_model_config, f"Model configuration for '{model_name}' must be a 'ModelConfig' object."
 
 
-def test_get_supported_models_with_azure(sample_azure_deployment):
+def test_get_supported_models_with_azure():
+    sample_azure_deployment = {"type": "azure", "model_name": "gpt-35-turbo", "deployment_name": "azure"}
     supported_models = get_supported_models(sample_azure_deployment)
 
     assert "GPT 3.5 Turbo" in supported_models
@@ -44,7 +38,8 @@ def test_get_supported_models_with_azure(sample_azure_deployment):
     assert supported_models["Mistral AI 7B"].type == "hf"
 
 
-def test_get_supported_models_with_openai_fallback(sample_openai_deployment):
+def test_get_supported_models_with_openai_fallback():
+    sample_openai_deployment = {"type": "openai", "model_name": "gpt-3.5-turbo", "deployment_name": ""}
     supported_models = get_supported_models(sample_openai_deployment)
 
     assert "GPT 3.5 Turbo" in supported_models
@@ -63,7 +58,6 @@ def test_get_supported_models_hugging_face_only():
     assert "GPT 3.5 Turbo" not in supported_models
     assert "Mistral AI 7B" in supported_models
     assert supported_models["Mistral AI 7B"].type == "hf"
-    assert "Llama 3 8B Instruct" in supported_models
 
 
 def test_get_supported_models_invalid_openai_deployment():


### PR DESCRIPTION
## Purpose
Add tests for the retrieval of available models for a given setup/deployment from the supported_models dictionary.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Does this require changes to learn.microsoft.com docs?

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Code quality checklist

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
